### PR TITLE
stay alive modifier changes

### DIFF
--- a/Content.Server/_StationWare/Challenges/Modifiers/Systems/StayAliveModifierSystem.cs
+++ b/Content.Server/_StationWare/Challenges/Modifiers/Systems/StayAliveModifierSystem.cs
@@ -23,7 +23,8 @@ public sealed class StayAliveModifierSystem : EntitySystem
 
         foreach (var player in args.Players)
         {
-            _stationWareChallenge.SetPlayerChallengeState(player, uid, _mobState.IsAlive(player), challenge);
+            if (_mobState.IsAlive(player))
+                _stationWareChallenge.SetPlayerChallengeState(player, uid, true, challenge);
         }
     }
 

--- a/Content.Server/_StationWare/Challenges/Modifiers/Systems/StayAliveModifierSystem.cs
+++ b/Content.Server/_StationWare/Challenges/Modifiers/Systems/StayAliveModifierSystem.cs
@@ -12,20 +12,7 @@ public sealed class StayAliveModifierSystem : EntitySystem
     /// <inheritdoc/>
     public override void Initialize()
     {
-        SubscribeLocalEvent<StayAliveModifierComponent, BeforeChallengeEndEvent>(OnBeforeChallengeEnd);
         SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
-    }
-
-    private void OnBeforeChallengeEnd(EntityUid uid, StayAliveModifierComponent component, ref BeforeChallengeEndEvent args)
-    {
-        if (!TryComp<StationWareChallengeComponent>(uid, out var challenge))
-            return;
-
-        foreach (var player in args.Players)
-        {
-            if (_mobState.IsAlive(player))
-                _stationWareChallenge.SetPlayerChallengeState(player, uid, true, challenge);
-        }
     }
 
     private void OnMobStateChanged(MobStateChangedEvent ev)

--- a/Resources/Prototypes/Challenges/challenges.yml
+++ b/Resources/Prototypes/Challenges/challenges.yml
@@ -1,6 +1,7 @@
 - type: challenge
   id: DeathBallChallenge
   announcement: challenge-death-ball
+  winByDefault: true
   duration: 10
   challengeModifiers:
   - type: StayAliveModifier
@@ -145,6 +146,7 @@
 - type: challenge
   id: ShootoutChallenge
   announcement: challenge-shootout
+  winByDefault: true
   duration: 15
   challengeModifiers:
   - type: StayAliveModifier
@@ -202,6 +204,7 @@
 - type: challenge
   id: WizardDuelChallenge
   announcement: challenge-wizard-duel
+  winByDefault: true
   duration: 10
   challengeModifiers:
   - type: StayAliveModifier
@@ -249,6 +252,7 @@
 - type: challenge
   id: OneShotGunChallenge
   announcement: challenge-one-shot-gun
+  winByDefault: true
   duration: 10
   startDelay: 1
   challengeModifiers:
@@ -269,6 +273,7 @@
 - type: challenge
   id: AcidTripChallenge
   announcement: challenge-acid-trip
+  winByDefault: true
   duration: 15
   challengeModifiers:
   - type: StayAliveModifier
@@ -279,6 +284,7 @@
 - type: challenge
   id: PutThatHelmetOnChallenge
   announcement: challenge-put-that-helmet-on
+  winByDefault: true
   startDelay: 0
   duration: 5
   challengeModifiers:
@@ -294,6 +300,7 @@
 - type: challenge
   id: GreytideChallenge
   announcement: challenge-greytide
+  winByDefault: true
   duration: 5
   startDelay: 0
   challengeModifiers:
@@ -307,6 +314,7 @@
 - type: challenge
   id: LandmineChallenge
   announcement: challenge-landmine
+  winByDefault: true
   duration: 5
   startDelay: 3
   challengeModifiers:
@@ -327,6 +335,7 @@
 - type: challenge
   id: MorbChallenge
   announcement: challenge-morb
+  winByDefault: true
   duration: 10
   startDelay: 3
   challengeModifiers:
@@ -353,6 +362,7 @@
 - type: challenge
   id: XenosChallenge
   announcement: challenge-xenos
+  winByDefault: true
   duration: 10
   startDelay: 3
   challengeModifiers:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
changes it so that it doesn't force wins/losses
this is just so it plays nice with multiple simultaneous win conditions

basically, now it just fails you for dying. previously it would give you a win for being alive.
we might want challenges in the future where you have to stay alive AND do something else.
this makes that possible

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

minor tweaks to stayalivemodifier logic.
