### PR TITLE
Fixes round dying bug

### DIFF
--- a/Content.Server/_StationWare/Challenges/Modifiers/Systems/EquipClothingModifierSystem.cs
+++ b/Content.Server/_StationWare/Challenges/Modifiers/Systems/EquipClothingModifierSystem.cs
@@ -31,15 +31,21 @@ public sealed class EquipClothingModifierSystem : EntitySystem
         foreach (var player in args.Players.Take(playerAmount))
         {
             var xform = Transform(player);
-            var slots = _inventory.GetSlots(player);
+            if (!TryComp<InventoryComponent>(player, out var inventory))
+                continue;
+            var slots = _inventory.GetSlots(player, inventory);
             var spawns = EntitySpawnCollection.GetSpawns(component.Spawns, _random);
             foreach (var spawn in spawns)
             {
                 var clothing = Spawn(spawn, xform.Coordinates);
                 if (slots.Any(slot => _inventory.CanEquip(player, clothing, slot.Name, out _, slot) &&
-                                      _inventory.TryEquip(player, clothing, slot.Name, true, true)))
+                                      _inventory.TryEquip(player, clothing, slot.Name, true)))
                 {
                     component.SpawnedEntities.Add(clothing);
+                }
+                else
+                {
+                    Del(clothing);
                 }
             }
         }

--- a/Content.Server/_StationWare/Challenges/Modifiers/Systems/EquipClothingModifierSystem.cs
+++ b/Content.Server/_StationWare/Challenges/Modifiers/Systems/EquipClothingModifierSystem.cs
@@ -39,7 +39,7 @@ public sealed class EquipClothingModifierSystem : EntitySystem
             {
                 var clothing = Spawn(spawn, xform.Coordinates);
                 if (slots.Any(slot => _inventory.CanEquip(player, clothing, slot.Name, out _, slot) &&
-                                      _inventory.TryEquip(player, clothing, slot.Name, true)))
+                                      _inventory.TryEquip(player, clothing, slot.Name, true, inventory: inventory)))
                 {
                     component.SpawnedEntities.Add(clothing);
                 }

--- a/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
@@ -72,7 +72,7 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
         var announcement = Loc.GetString(challengePrototype.Announcement);
         _chat.DispatchGlobalAnnouncement(announcement, announcementSound: challengePrototype.AnnouncementSound, colorOverride: Color.Fuchsia);
 
-        _overlay.BroadcastText(announcement, true, Color.Fuchsia, null);
+        _overlay.BroadcastText(announcement, true, Color.Fuchsia);
 
         return uid;
     }
@@ -85,6 +85,7 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
         var beforeEv = new BeforeChallengeEndEvent(GetEntitiesFromNetUserIds(component.Completions.Keys).ToList(), component);
         RaiseLocalEvent(uid, ref beforeEv);
 
+        _overlay.BroadcastText(string.Empty, true, Color.White);
 
         foreach (var (player, completion) in component.Completions)
         {
@@ -221,6 +222,13 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
 
             if (session.AttachedEntity is not {} ent)
                 continue;
+
+            if (HasComp<GhostComponent>(ent))
+                continue;
+
+            if (_mobState.IsIncapacitated(ent))
+                continue;
+
             yield return ent;
         }
     }

--- a/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
@@ -165,6 +165,9 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
         var enumerator = EntityQueryEnumerator<ActorComponent, MobStateComponent>();
         while (enumerator.MoveNext(out var uid, out var actor, out var mobState))
         {
+            if (HasComp<GhostComponent>(uid))
+                continue;
+
             if (_mobState.IsDead(uid, mobState))
                 continue;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Closes #162 
Closes #161 
Closes #157 ( i think )

basically does a few things
- ghosts no longer count as eligible player ents for a challenge
- equipclothingmodifier deletes clothing that wasn't added successfully
- equipclothingmodifier no longer throws hella exceptions if a player lacks InventoryComponent (see thing about ghosts)

i'm pretty sure this was just spamming exceptions out the ass which was what caused everything to die.
reasonably sure those things should be fixed now.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
no cl no fun
