### PR TITLE
End challenges early if everyone completes them

### DIFF
--- a/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.Ghost.Components;
 using Content.Server.Spawners.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Console;
@@ -111,6 +112,26 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
     }
 
     /// <summary>
+    /// Ends the challenge early if everyone has already completed it.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="component"></param>
+    /// <returns></returns>
+    [PublicAPI]
+    public bool TryEndChallengeEarly(EntityUid uid, StationWareChallengeComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return false;
+
+        if (component.Completions.Values.Any(v => v == null))
+            return false;
+
+        // Queues the challenge to end on the next tick.
+        component.EndTime = TimeSpan.Zero;
+        return true;
+    }
+
+    /// <summary>
     /// Sets a player as winning a challenge.
     /// </summary>
     /// <param name="uid"></param>
@@ -155,6 +176,7 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
         var ev = new PlayerChallengeStateSetEvent(challengeEnt, actor.PlayerSession, win);
         RaiseLocalEvent(uid, ref ev);
         RaiseLocalEvent(challengeEnt, ref ev, true);
+        TryEndChallengeEarly(challengeEnt, component);
         return true;
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Closes #149 
tl;dr no one likes waiting around when everyone died early.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no fun
