### PR TITLE
Challenge speedup

### DIFF
--- a/Content.Server/_StationWare/Challenges/ChallengePrototype.cs
+++ b/Content.Server/_StationWare/Challenges/ChallengePrototype.cs
@@ -42,6 +42,13 @@ public sealed class ChallengePrototype : IPrototype
     public readonly TimeSpan StartDelay = TimeSpan.Zero;
 
     /// <summary>
+    /// If true, the duration of a challenge will
+    /// increase with speedup rather than decrease.
+    /// </summary>
+    [DataField("invertSpeedup")]
+    public bool InvertSpeedup;
+
+    /// <summary>
     /// The announcement played when the event starts
     /// </summary>
     [DataField("announcement")]

--- a/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
@@ -45,14 +45,18 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
             StartChallengeCommandCompletions);
     }
 
-    public EntityUid StartChallenge(ChallengePrototype challengePrototype)
+    public EntityUid StartChallenge(ChallengePrototype challengePrototype, float challengeTimeMultiplier = 1)
     {
         var uid = Spawn(null, MapCoordinates.Nullspace);
         var challengeComp = AddComp<StationWareChallengeComponent>(uid);
-        challengeComp.StartTime = _timing.CurTime + challengePrototype.StartDelay;
-        challengeComp.EndTime = _timing.CurTime + challengePrototype.Duration + challengePrototype.StartDelay; // time modifiers?
+        var duration = challengePrototype.Duration * (challengePrototype.InvertSpeedup
+            ? 1f + (1f - challengeTimeMultiplier)
+            : challengeTimeMultiplier);
+        var startDelay = challengePrototype.StartDelay * challengeTimeMultiplier;
+        challengeComp.StartTime = _timing.CurTime + startDelay;
+        challengeComp.EndTime = _timing.CurTime + duration + startDelay;
         challengeComp.WinByDefault = challengePrototype.WinByDefault;
-        var participants = GetParticipants(); // get all of the players for this challenge
+        var participants = GetParticipants();
 
         // copy all our modifiers from the challenge component to the entity
         foreach (var (name, entry) in challengePrototype.ChallengeModifiers)

--- a/Content.Server/_StationWare/GameRules/StationWareRuleSystem.cs
+++ b/Content.Server/_StationWare/GameRules/StationWareRuleSystem.cs
@@ -43,8 +43,12 @@ public sealed class StationWareRuleSystem : GameRuleSystem
 
     private readonly HashSet<string> _previousChallenges = new();
 
-    private int _totalChallenges = 10;
+    private int _totalChallenges = 15;
     private int _challengeCount = 1;
+    private int _speedupInterval = 5;
+    private float _amountPerSpeedup = 0.15f;
+
+    private float _speedMultiplier = 1f;
 
     private readonly HashSet<IPlayerSession> _queuedRespawns = new();
 
@@ -62,6 +66,8 @@ public sealed class StationWareRuleSystem : GameRuleSystem
 
         _configuration.OnValueChanged(CCVars.StationWareTotalChallenges, e => _totalChallenges = e, true);
         _configuration.OnValueChanged(CCVars.StationWareChallengeCooldownLength, e => _challengeDelay = TimeSpan.FromSeconds(e), true);
+        _configuration.OnValueChanged(CCVars.StationWareSpeedupInterval, e => _speedupInterval = e, true);
+        _configuration.OnValueChanged(CCVars.StationWareAmountPerSpeedup, e => _amountPerSpeedup = e, true);
     }
 
     private void OnChallengeEnd(ref ChallengeEndEvent ev)
@@ -80,10 +86,16 @@ public sealed class StationWareRuleSystem : GameRuleSystem
             return;
         }
 
+        if (_challengeCount % _speedupInterval == 0)
+        {
+            _speedMultiplier -= _amountPerSpeedup;
+            _chatManager.DispatchServerAnnouncement(Loc.GetString("stationware-speed-up"), Color.Cyan);
+            //todo: sfx
+        }
         _challengeCount++;
 
         _currentChallenge = null;
-        _nextChallengeTime = _timing.CurTime + _challengeDelay;
+        _nextChallengeTime = _timing.CurTime + _challengeDelay * _speedMultiplier;
     }
 
     private void OnMobStateChanged(MobStateChangedEvent ev)
@@ -127,6 +139,7 @@ public sealed class StationWareRuleSystem : GameRuleSystem
         _currentChallenge = null;
         _restartRoundTime = null;
         _nextChallengeTime = _timing.CurTime + _challengeDelay;
+        _speedMultiplier = 1;
         _point.CreatePointManager(); //initialize it for the overlay
     }
 
@@ -164,7 +177,7 @@ public sealed class StationWareRuleSystem : GameRuleSystem
             return;
 
         var challenge = GetRandomChallenge();
-        _currentChallenge = _stationWareChallenge.StartChallenge(challenge);
+        _currentChallenge = _stationWareChallenge.StartChallenge(challenge, _speedMultiplier);
         _previousChallenges.Add(challenge.ID);
     }
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1205,7 +1205,19 @@ namespace Content.Shared.CCVar
         ///     How many challenges are in a single stationware round
         /// </summary>
         public static readonly CVarDef<int> StationWareTotalChallenges =
-            CVarDef.Create("stationware.total_challenges", 10, CVar.SERVERONLY);
+            CVarDef.Create("stationware.total_challenges", 15, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Every X challenges, the challenges themselves will speedup
+        /// </summary>
+        public static readonly CVarDef<float> StationWareAmountPerSpeedup =
+            CVarDef.Create("stationware.amount_per_speedup", 0.15f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Every X challenges, the challenges themselves will speedup
+        /// </summary>
+        public static readonly CVarDef<int> StationWareSpeedupInterval =
+            CVarDef.Create("stationware.speedup_interval", 5, CVar.SERVERONLY);
 
         /// <summary>
         ///     How much time do we wait between each challenge

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-stationware.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-stationware.ftl
@@ -7,3 +7,5 @@ stationware-report-winner = {$points ->
     [one] [color=cyan]{$name}[/color] was the winner with a measly [color=yellow]{$points} point![/color]
     *[other] [color=cyan]{$name}[/color] was the winner with a total of [color=yellow]{$points} points![/color]
 }
+
+stationware-speed-up = Speeding up!

--- a/Resources/Prototypes/Challenges/challenges.yml
+++ b/Resources/Prototypes/Challenges/challenges.yml
@@ -3,6 +3,7 @@
   announcement: challenge-death-ball
   winByDefault: true
   duration: 10
+  invertSpeedup: true
   challengeModifiers:
   - type: StayAliveModifier
   - type: SpawnEntityModifier
@@ -37,6 +38,7 @@
   winByDefault: true
   startDelay: 1
   duration: 5
+  invertSpeedup: true
   challengeModifiers:
   - type: KeepMovingModifier
 
@@ -163,6 +165,7 @@
   winByDefault: true
   startDelay: 3
   duration: 10
+  invertSpeedup: true
   challengeModifiers:
   - type: StayAliveModifier
   - type: StayOnGridModifier
@@ -211,6 +214,7 @@
   announcement: challenge-xeno-queen
   winByDefault: true
   duration: 15
+  invertSpeedup: true
   challengeModifiers:
   - type: StayAliveModifier
   - type: StayOnGridModifier
@@ -366,6 +370,7 @@
   announcement: challenge-morb
   winByDefault: true
   duration: 10
+  invertSpeedup: true
   startDelay: 3
   challengeModifiers:
   - type: StayAliveModifier
@@ -393,6 +398,7 @@
   announcement: challenge-xenos
   winByDefault: true
   duration: 10
+  invertSpeedup: true
   startDelay: 3
   challengeModifiers:
   - type: StayAliveModifier


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
adds a system that speeds up challenges.
currently does 15% every 5 challenges (speeds up twice during the 15 total)
just makes everything last less time.
tested and works fine.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no bot