### PR TITLE
Fix challenges not ending

### DIFF
--- a/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
@@ -110,14 +110,13 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
         {
             if (completion != null)
                 continue;
-            if (!_player.TryGetSessionById(player, out var session) || session.AttachedEntity is not { } attachedEntity)
+            if (!_player.TryGetSessionById(player, out var session) ||
+                session.AttachedEntity is not { } attachedEntity ||
+                SetPlayerChallengeState(attachedEntity, uid, component.WinByDefault, component))
             {
                 // Automatically make players fail if they're not in the game
                 component.Completions[player] = false;
-                continue;
             }
-
-            SetPlayerChallengeState(attachedEntity, uid, component.WinByDefault, component);
         }
 
         Dictionary<NetUserId, bool> finalCompletions = new();

--- a/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
@@ -112,7 +112,7 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
                 continue;
             if (!_player.TryGetSessionById(player, out var session) ||
                 session.AttachedEntity is not { } attachedEntity ||
-                SetPlayerChallengeState(attachedEntity, uid, component.WinByDefault, component))
+                !SetPlayerChallengeState(attachedEntity, uid, component.WinByDefault, component))
             {
                 // Automatically make players fail if they're not in the game
                 component.Completions[player] = false;

--- a/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
@@ -111,17 +111,25 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
             if (completion != null)
                 continue;
             if (!_player.TryGetSessionById(player, out var session) || session.AttachedEntity is not { } attachedEntity)
-                continue;
-            if (!SetPlayerChallengeState(attachedEntity, uid, component.WinByDefault, component))
             {
-                component.Completions[player] = component.WinByDefault;
+                // Automatically make players fail if they're not in the game
+                component.Completions[player] = false;
+                continue;
             }
+
+            SetPlayerChallengeState(attachedEntity, uid, component.WinByDefault, component);
         }
 
         Dictionary<NetUserId, bool> finalCompletions = new();
         foreach (var (player, completion)  in component.Completions)
         {
-            finalCompletions.Add(player, completion!.Value);
+            if (completion == null)
+            {
+                Logger.Error($"Null completion for challenge {ToPrettyString(uid)}: {player}, {player.UserId}");
+                continue;
+            }
+
+            finalCompletions.Add(player, completion.Value);
         }
 
         var ev = new ChallengeEndEvent(GetEntitiesFromNetUserIds(component.Completions.Keys).ToList(), finalCompletions, uid, component);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
After some local playtesting and session shenanigans, i was able to determine that, occasionally, a player's challenge state won't get set. This seems to be relating to multiple entities tied to a session, which is the kind of nonsense behavior i just about expected. Nonetheless, unexpected it may be, it probably shouldn't kill the round.

Adds a few basic safeguards. Firstly, a disconnected session automatically is set to lose.

Additionally, we scrap the shitty `!` and replace it with an actual null check. The fact that i did that in the first place just shows what a giga idiot i am.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no fun
