### PR TITLE
Add a modifier for limiting the winners per challenge

### DIFF
--- a/Content.Server/_StationWare/Challenges/Modifiers/Components/WinLimiterComponent.cs
+++ b/Content.Server/_StationWare/Challenges/Modifiers/Components/WinLimiterComponent.cs
@@ -1,0 +1,22 @@
+﻿namespace Content.Server._StationWare.Challenges.Modifiers.Components;
+
+/// <summary>
+/// This is used for limiting the amount of winners in a challenge.
+/// </summary>
+[RegisterComponent]
+public sealed class WinLimiterComponent : Component
+{
+    /// <summary>
+    /// The numerical amount of players that are allowed to win.
+    /// </summary>
+    [DataField("limit")]
+    public int Limit;
+
+    /// <summary>
+    /// A percentag of players that are allowed to win. Overrides <see cref="Limit"/>
+    /// </summary>
+    [DataField("limitPercent")]
+    public float? LimitPercent;
+
+    public bool Ending;
+}

--- a/Content.Server/_StationWare/Challenges/Modifiers/Systems/WinLimiterSystem.cs
+++ b/Content.Server/_StationWare/Challenges/Modifiers/Systems/WinLimiterSystem.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq;
+using Content.Server._StationWare.Challenges.Modifiers.Components;
+
+namespace Content.Server._StationWare.Challenges.Modifiers.Systems;
+
+public sealed class WinLimiterSystem : EntitySystem
+{
+    [Dependency] private readonly StationWareChallengeSystem _stationWareChallenge = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<WinLimiterComponent, PlayerChallengeStateSetEvent>(OnPlayerChallengeStateSet);
+    }
+
+    private void OnPlayerChallengeStateSet(EntityUid uid, WinLimiterComponent component, ref PlayerChallengeStateSetEvent args)
+    {
+        if (component.Ending || !args.Won)
+            return;
+
+        var totalPlayers = args.Component.Completions.Count;
+
+        var limit = component.LimitPercent == null
+            ? component.Limit
+            : (int) Math.Clamp(totalPlayers * component.LimitPercent.Value, 0, args.Component.Completions.Count);
+
+        var wins = args.Component.Completions.Count(p => p.Value == true);
+        if (wins < limit)
+            return;
+        component.Ending = true;
+        foreach (var player in args.Component.Completions.Keys)
+        {
+            _stationWareChallenge.SetPlayerChallengeState(player, uid, false, args.Component);
+        }
+    }
+}

--- a/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
@@ -150,6 +150,18 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
         return true;
     }
 
+    public bool SetPlayerChallengeState(NetUserId id,
+        EntityUid challengeEnt,
+        bool win,
+        StationWareChallengeComponent? component = null,
+        ActorComponent? actor = null)
+    {
+        if (!_player.TryGetSessionById(id, out var session) || session.AttachedEntity is not { } attached)
+            return false;
+
+        return SetPlayerChallengeState(attached, challengeEnt, win, component, actor);
+    }
+
     /// <summary>
     /// Sets a player as winning a challenge.
     /// </summary>
@@ -192,7 +204,7 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
             _overlay.BroadcastText(Loc.GetString("overlay-lost"), true, Color.Red, actor.PlayerSession);
         }
 
-        var ev = new PlayerChallengeStateSetEvent(challengeEnt, actor.PlayerSession, win);
+        var ev = new PlayerChallengeStateSetEvent(challengeEnt, component, actor.PlayerSession, win);
         RaiseLocalEvent(uid, ref ev);
         RaiseLocalEvent(challengeEnt, ref ev, true);
         TryEndChallengeEarly(challengeEnt, component);
@@ -337,4 +349,4 @@ public readonly record struct ChallengeEndEvent(List<EntityUid> Players, Diction
 /// <param name="Player"></param>
 /// <param name="Won"></param>
 [ByRefEvent]
-public readonly record struct PlayerChallengeStateSetEvent(EntityUid Challenge, IPlayerSession Player, bool Won);
+public readonly record struct PlayerChallengeStateSetEvent(EntityUid Challenge, StationWareChallengeComponent Component, IPlayerSession Player, bool Won);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Closes #128

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
no cl no fun